### PR TITLE
Retrait du chemin absolu vers les certificats SSL

### DIFF
--- a/THSF2017.py
+++ b/THSF2017.py
@@ -16,8 +16,8 @@ rs.sort_replies()
 
 from OpenSSL import SSL
 context = SSL.Context(SSL.SSLv23_METHOD)
-context.use_privatekey_file('/home/noghost/TIM/certificats/ADA.key')
-context.use_certificate_file('/home/noghost/TIM/certificats/ADA.crt')
+context.use_privatekey_file('./certificats/ADA.key')
+context.use_certificate_file('./certificats/ADA.crt')
 
 from scapy.all import *
 


### PR DESCRIPTION
Retrait du chemin absolu vers les certificats /home/noghost pour un chemin relatif ./certificats/....